### PR TITLE
refactor: use email in profile update

### DIFF
--- a/nexus-aura-backend/src/main/kotlin/com/nexus/aura/backend/nexus_aura_backend/controller/UserController.kt
+++ b/nexus-aura-backend/src/main/kotlin/com/nexus/aura/backend/nexus_aura_backend/controller/UserController.kt
@@ -23,8 +23,8 @@ class UserController(
         @Valid @RequestBody request: UserProfileUpdateRequest
     ): ResponseEntity<*> {
         return try {
-            val username = authentication.name
-            val updatedUser = userService.updateUserProfile(username, request)
+            val email = authentication.name
+            val updatedUser = userService.updateUserProfile(email, request)
             ResponseEntity.ok(updatedUser)
         } catch (e: com.nexus.aura.backend.nexus_aura_backend.exception.UserNotFoundException) {
             ResponseEntity.status(404).body(e.message ?: "User not found")


### PR DESCRIPTION
## Summary
- use authenticated email for profile updates

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_689855e68f30832c9ccd261f472330b5