### PR TITLE
docs: update backend run instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,8 +144,8 @@ Nexus Aura is deployed within a Kubernetes cluster, leveraging Docker containers
 ### Installation
 
 1. Clone the repository: `git clone https://github.com/Leobej/NexusAura.git`
-2. Navigate to the backend directory: `cd backend`
-3. Build and run the backend application: `./mvnw spring-boot:run`
+2. Navigate to the backend directory: `cd nexus-aura-backend`
+3. Build and run the backend application: `./gradlew bootRun`
 4. Navigate to the web app directory: `cd web-app`
 5. Install dependencies: `npm install`
 6. Start the web app: `npm start`

--- a/nexus-aura-backend/README.md
+++ b/nexus-aura-backend/README.md
@@ -144,8 +144,8 @@ Nexus Aura is deployed within a Kubernetes cluster, leveraging Docker containers
 ### Installation
 
 1. Clone the repository: `git clone https://github.com/Leobej/NexusAura.git`
-2. Navigate to the backend directory: `cd backend`
-3. Build and run the backend application: `./mvnw spring-boot:run`
+2. Navigate to the backend directory: `cd nexus-aura-backend`
+3. Build and run the backend application: `./gradlew bootRun`
 4. Navigate to the web app directory: `cd web-app`
 5. Install dependencies: `npm install`
 6. Start the web app: `npm start`


### PR DESCRIPTION
## Summary
- update root and backend README instructions to use `cd nexus-aura-backend`
- swap Maven run command for Gradle `./gradlew bootRun`
- verify no remaining references to old backend path or Maven wrapper

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden" )*

------
https://chatgpt.com/codex/tasks/task_e_689856030734832c9ab77f9e67726ced