### PR TITLE
Add password reset email test

### DIFF
--- a/nexus-aura-backend/src/main/kotlin/com/nexus/aura/backend/nexus_aura_backend/service/EmailService.kt
+++ b/nexus-aura-backend/src/main/kotlin/com/nexus/aura/backend/nexus_aura_backend/service/EmailService.kt
@@ -8,12 +8,12 @@ import org.springframework.stereotype.Service
 @Service
 class EmailService(private val mailSender: JavaMailSender) : EmailSender {
     override fun send(to: String, subject: String, body: String) {
-        // Disabled email sending: mailSender.send(message)
-        // val message = SimpleMailMessage()
-        // message.setTo(to)
-        // message.subject = subject
-        // message.text = body
-        // mailSender.send(message)
+        val message = SimpleMailMessage().apply {
+            setTo(to)
+            this.subject = subject
+            this.text = body
+        }
+        mailSender.send(message)
     }
 
     fun sendPasswordResetEmail(to: String, resetLink: String) {

--- a/nexus-aura-backend/src/test/kotlin/com/nexus/aura/backend/nexus_aura_backend/service/EmailServiceTest.kt
+++ b/nexus-aura-backend/src/test/kotlin/com/nexus/aura/backend/nexus_aura_backend/service/EmailServiceTest.kt
@@ -1,17 +1,23 @@
 package com.nexus.aura.backend.nexus_aura_backend.service
 
 import org.junit.jupiter.api.Test
-
 import org.junit.jupiter.api.Assertions.*
+import org.mockito.ArgumentCaptor
+import org.mockito.Mockito.verify
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
-
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.mail.SimpleMailMessage
+import org.springframework.mail.javamail.JavaMailSender
 
 @SpringBootTest
 class EmailServiceTest {
 
     @Autowired
     private lateinit var emailService: EmailService
+
+    @MockBean
+    private lateinit var mailSender: JavaMailSender
 
     @Test
     fun contextLoads() {
@@ -20,6 +26,17 @@ class EmailServiceTest {
 
     @Test
     fun sendPasswordResetEmail() {
-        // Implement your test logic here
+        val email = "test@example.com"
+        val resetLink = "http://example.com/reset?token=123"
+
+        emailService.sendPasswordResetEmail(email, resetLink)
+
+        val messageCaptor = ArgumentCaptor.forClass(SimpleMailMessage::class.java)
+        verify(mailSender).send(messageCaptor.capture())
+        val message = messageCaptor.value
+
+        assertEquals(email, message.to?.get(0))
+        assertEquals("Password Reset Request", message.subject)
+        assertEquals("To reset your password, click the link below:\n$resetLink", message.text)
     }
 }


### PR DESCRIPTION
## Summary
- Enable EmailService `send` method to construct and dispatch `SimpleMailMessage`
- Add unit test verifying password reset emails are sent with correct content

## Testing
- `gradle test` *(fails: Plugin [id: 'org.jetbrains.kotlin.jvm', version: '1.9.25'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68985602d6e4832cb0fd4a0ce2d08edd